### PR TITLE
Update BatteryLevelMonitor.java

### DIFF
--- a/src/main/java/org/radarcns/monitor/BatteryLevelMonitor.java
+++ b/src/main/java/org/radarcns/monitor/BatteryLevelMonitor.java
@@ -97,8 +97,9 @@ public class BatteryLevelMonitor extends
                             key.getSourceId(), key.getUserId(), record.value());
                 }
             } else if (previousLevel <= Status.LOW.getLevel()) {
-                 // Remove the email alert for battery monitor for normal level because it is not crucial 
-                //  and to prevent spamming a user's email account. Uncomment the line below if needed.
+                // Remove the email alert for battery monitor for normal level because 
+                // it is not crucial and to prevent spamming a user's email account. 
+                // Uncomment the line below if needed.
                 // updateStatus(key, Status.NORMAL);
                 logger.info("Battery of sensor {} of user {} is has returned to normal: {}",
                         key.getSourceId(), key.getUserId(), record.value());

--- a/src/main/java/org/radarcns/monitor/BatteryLevelMonitor.java
+++ b/src/main/java/org/radarcns/monitor/BatteryLevelMonitor.java
@@ -97,7 +97,7 @@ public class BatteryLevelMonitor extends
                             key.getSourceId(), key.getUserId(), record.value());
                 }
             } else if (previousLevel <= Status.LOW.getLevel()) {
-                updateStatus(key, Status.NORMAL);
+                // updateStatus(key, Status.NORMAL);
                 logger.info("Battery of sensor {} of user {} is has returned to normal: {}",
                         key.getSourceId(), key.getUserId(), record.value());
             }

--- a/src/main/java/org/radarcns/monitor/BatteryLevelMonitor.java
+++ b/src/main/java/org/radarcns/monitor/BatteryLevelMonitor.java
@@ -97,6 +97,8 @@ public class BatteryLevelMonitor extends
                             key.getSourceId(), key.getUserId(), record.value());
                 }
             } else if (previousLevel <= Status.LOW.getLevel()) {
+                 // Remove the email alert for battery monitor for normal level because it is not crucial 
+                //  and to prevent spamming a user's email account. Uncomment the line below if needed.
                 // updateStatus(key, Status.NORMAL);
                 logger.info("Battery of sensor {} of user {} is has returned to normal: {}",
                         key.getSourceId(), key.getUserId(), record.value());

--- a/src/test/java/org/radarcns/monitor/BatteryLevelMonitorTest.java
+++ b/src/test/java/org/radarcns/monitor/BatteryLevelMonitorTest.java
@@ -89,14 +89,14 @@ public class BatteryLevelMonitorTest {
         sendMessage(monitor, 1.0f, false);
         sendMessage(monitor, 0.1f, true);
         sendMessage(monitor, 0.1f, false);
-        sendMessage(monitor, 0.3f, true);
+        sendMessage(monitor, 0.3f, false);
         sendMessage(monitor, 0.4f, false);
         sendMessage(monitor, 0.01f, true);
         sendMessage(monitor, 0.01f, false);
         sendMessage(monitor, 0.1f, false);
         sendMessage(monitor, 0.1f, false);
         sendMessage(monitor, 0.01f, true);
-        sendMessage(monitor, 1f, true);
+        sendMessage(monitor, 1f, false);
     }
 
     private void sendMessage(BatteryLevelMonitor monitor, float batteryLevel, boolean sentMessage)


### PR DESCRIPTION
Remove the email alert for battery monitor for normal level because it is not crucial and to close #24 