### PR TITLE
Increase test timeout

### DIFF
--- a/src/integrationTest/java/org/radarcns/integration/PhoneStreamTest.java
+++ b/src/integrationTest/java/org/radarcns/integration/PhoneStreamTest.java
@@ -114,7 +114,7 @@ public class PhoneStreamTest {
         backend.shutdown();
     }
 
-    @Test(timeout = 600_000L)
+    @Test(timeout = 3000_000L)
     public void testDirect() throws Exception {
         ConfigRadar config = propHandler.getRadarProperties();
 


### PR DESCRIPTION
Increase the timeout for integration test since it fails sometimes during travis build due to timeout